### PR TITLE
FIX Unindent models config

### DIFF
--- a/_config/graphql.yml
+++ b/_config/graphql.yml
@@ -28,32 +28,32 @@ SilverStripe\GraphQL\Schema\Schema:
           type_mapping:
             SilverStripe\FrameworkTest\Model\Company: Company
             SilverStripe\FrameworkTest\Model\Employee: Employee
-        models:
-          SilverStripe\FrameworkTest\Model\Company:
-            fields:
-              ID: true
-              Name: true
-              Category: true
-              Revenue: true
-              CEO: true
-              Employees: true
-              PastEmployees: true
-            operations:
-              read: true
-              update: true
-              create: true
-              delete: true
-              readOne: true
-          SilverStripe\FrameworkTest\Model\Employee:
-            fields:
-              ID: true
-              Name: true
-              Biography: true
-              DateOfBirth: true
-              Category: true
-            operations:
-              read: true
-              update: true
-              create: true
-              delete: true
-              readOne: true
+      models:
+        SilverStripe\FrameworkTest\Model\Company:
+          fields:
+            ID: true
+            Name: true
+            Category: true
+            Revenue: true
+            CEO: true
+            Employees: true
+            PastEmployees: true
+          operations:
+            read: true
+            update: true
+            create: true
+            delete: true
+            readOne: true
+        SilverStripe\FrameworkTest\Model\Employee:
+          fields:
+            ID: true
+            Name: true
+            Biography: true
+            DateOfBirth: true
+            Category: true
+          operations:
+            read: true
+            update: true
+            create: true
+            delete: true
+            readOne: true


### PR DESCRIPTION
'model' node was underneath 'config' instead of its sibling

This matches indent level matches [this](https://github.com/silverstripe/silverstripe-frameworktest/pull/84/files#diff-4920863783d892e3b07e9a49190ac3207828e5cf3e735a33fbcc872f5e5984b9R27) and [this](https://github.com/silverstripe/silverstripe-graphql/blob/master/tests/Schema/_testQueriesAndMutations/schema.yml#L24)
