### PR TITLE
NEW Add new page for testing elemental blocks on a page.

### DIFF
--- a/code/elemental/BasicElementalPage.php
+++ b/code/elemental/BasicElementalPage.php
@@ -1,0 +1,10 @@
+<?php
+
+use DNADesign\Elemental\Extensions\ElementalPageExtension;
+
+class BasicElementalPage extends Page
+{
+    private static $extensions = [
+        ElementalPageExtension::class,
+    ];
+}


### PR DESCRIPTION
Required for behat testing in silverstripe/silverstripe-elemental#911
I tried using a pre-existing subclass of `Page` and applying the extension to it in the behat test, but there seems to be some weird bug with the way we do behat tests where the extension from the previous test was being sort-of-but-not-really applied to `Page` if I did that. I don't really understand exactly what was happening, but this resolves that problem and lets us do the test.

Specifically, it's required if doing a behat test with one page that _doesn't_ have the `ElementalPageExtension` and another page that _does_.

## Parent issue
- https://github.com/silverstripe/silverstripe-elemental/issues/186