### PR TITLE
DEP Allow guzzle 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "silverstripe/framework": "^4",
         "silverstripe/cms": "^4",
-        "guzzlehttp/guzzle": "^7.3",
+        "guzzlehttp/guzzle": "^6.3 || ^7.3",
         "fzaninotto/faker": "^1.7",
         "silverstripe/vendor-plugin": "^1",
         "silverstripe/registry": "^2"


### PR DESCRIPTION
Release 0.4.5 when merged

Allow guzzle 6 to install to support 4.10 recipe-kitchen-sink

Fixes https://github.com/silverstripe/recipe-kitchen-sink/runs/7173341868?check_suite_focus=true

```
  Problem 1
    - Root composer.json requires silverstripe/textextraction 3.3.x-dev -> satisfiable by silverstripe/textextraction[3.3.x-dev].
    - silverstripe/frameworktest 4.x-dev requires guzzlehttp/guzzle ^7.3 -> satisfiable by guzzlehttp/guzzle[7.3.0, ..., 7.4.x-dev].
    - You can only install one version of a package, so only one of these can be installed: guzzlehttp/guzzle[6.0.0, ..., 6.5.x-dev, 7.0.0-beta.1, ..., 7.4.x-dev].
    - silverstripe/textextraction 3.3.x-dev requires guzzlehttp/guzzle ~6.3.0 -> satisfiable by guzzlehttp/guzzle[6.3.0, 6.3.1, 6.3.2, 6.3.3].
    - Root composer.json requires silverstripe/frameworktest 4.x-dev -> satisfiable by silverstripe/frameworktest[4.x-dev].
```