### PR TITLE
FIX Remove types for PHP 7.3 support

### DIFF
--- a/code/elemental/ElementalBehatTestAdmin.php
+++ b/code/elemental/ElementalBehatTestAdmin.php
@@ -7,11 +7,11 @@ use SilverStripe\FrameworkTest\Elemental\Model\ElementalBehatTestObject;
 
 class ElementalBehatTestAdmin extends ModelAdmin
 {
-    private static string $url_segment = 'elemental-behat-test-admin';
-    private static string $menu_title = 'Elemental Behat Test Admin';
-    private static string $menu_icon_class = 'font-icon-block-banner';
+    private static $url_segment = 'elemental-behat-test-admin';
+    private static $menu_title = 'Elemental Behat Test Admin';
+    private static $menu_icon_class = 'font-icon-block-banner';
 
-    private static array $managed_models = [
+    private static $managed_models = [
         ElementalBehatTestObject::class,
     ];
 }

--- a/code/elemental/ElementalBehatTestObject.php
+++ b/code/elemental/ElementalBehatTestObject.php
@@ -8,7 +8,7 @@ use SilverStripe\ORM\DataObject;
 
 class ElementalBehatTestObject extends DataObject
 {
-    private static string $table_name = 'ElementalBehatTestObject';
+    private static $table_name = 'ElementalBehatTestObject';
 
     public function CMSEditLink()
     {

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         }
     ],
     "require": {
+        "php": "^7.3",
         "silverstripe/framework": "^4",
         "silverstripe/cms": "^4",
         "guzzlehttp/guzzle": "^6.3 || ^7.3",


### PR DESCRIPTION
Fix for 4.10 builds on PHP 7.3

e.g https://github.com/creative-commoners/silverstripe-admin/runs/7190631402?check_suite_focus=true

`PHP Parse error:  syntax error, unexpected 'string' (T_STRING), expecting function (T_FUNCTION) or const (T_CONST) in /home/runner/work/silverstripe-admin/silverstripe-admin/vendor/silverstripe/frameworktest/code/elemental`

Tag 0.4.6 when merged
