### PR TITLE
FIX Only add extension if elemental module exists

### DIFF
--- a/_config/extensions.yml
+++ b/_config/extensions.yml
@@ -20,3 +20,7 @@ SilverStripe\FrameworkTest\Elemental\Model\ElementalBehatTestObject:
   extensions:
     - DNADesign\Elemental\Extensions\ElementalAreasExtension
     - SilverStripe\FrameworkTest\Elemental\Extension\ElementalBehatTestExtension
+
+BasicElementalPage:
+  extensions:
+    - DNADesign\Elemental\Extensions\ElementalPageExtension

--- a/code/elemental/BasicElementalPage.php
+++ b/code/elemental/BasicElementalPage.php
@@ -1,10 +1,6 @@
 <?php
-
-use DNADesign\Elemental\Extensions\ElementalPageExtension;
+// DNADesign\Elemental\Extensions\ElementalPageExtension is added in extensions.yml
 
 class BasicElementalPage extends Page
 {
-    private static $extensions = [
-        ElementalPageExtension::class,
-    ];
 }


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/11

Fixes `ERROR [Emergency]: Uncaught InvalidArgumentException: BasicElementalPage references nonexistent DNADesign\Elemental\Extensions\ElementalPageExtension in 'extensions'`

https://github.com/creative-commoners/silverstripe-admin/runs/7190883651?check_suite_focus=true