### PR TITLE
FIX Use classexists instead of modulexists

### DIFF
--- a/_config/extensions.yml
+++ b/_config/extensions.yml
@@ -7,10 +7,10 @@ SilverStripe\ORM\DataObject:
 SilverStripe\Assets\File:
   extensions:
     - BasicFieldsTestFileExtension
-    
+
 ---
 Only:
-  moduleexists: 'dnadesign/silverstripe-elemental'
+  classexists: DNADesign\Elemental\Extensions\ElementalPageExtension
 ---
 SilverStripe\FrameworkTest\Model\TestPage:
   extensions:


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/37

Fix https://github.com/silverstripe/silverstripe-elemental/runs/7540220212?check_suite_focus=true

When run the root module is dnadesign/silverstripe-elemental, such as when running in CI, the 'moduleexists' syntax doesn't work correctly
