### PR TITLE
ENH Add permissions for Content Editor

### DIFF
--- a/code/Company.php
+++ b/code/Company.php
@@ -13,6 +13,8 @@ use SilverStripe\Versioned\RecursivePublishable;
 use SilverStripe\Versioned\Versioned;
 use RelationFieldsTestPage;
 use GridFieldTestPage;
+use SilverStripe\Security\Permission;
+use SilverStripe\Security\PermissionProvider;
 
 /**
  *
@@ -31,7 +33,7 @@ use GridFieldTestPage;
  * @mixin Versioned
  * @mixin RecursivePublishable
  */
-class Company extends DataObject
+class Company extends DataObject implements PermissionProvider
 {
     private static $table_name = 'Company';
 
@@ -370,4 +372,41 @@ class Company extends DataObject
     {
         return DropdownField::create('CompanyID', 'Company', self::get()->map())->setEmptyString('');
     }
+
+    public function providePermissions()
+    {
+        return [
+            'COMPANY_EDIT' => [
+                'name' => _t(
+                    __CLASS__ . '.EditPermissionLabel',
+                    'Edit a company'
+                ),
+                'category' => _t(
+                    __CLASS__ . '.Category',
+                    'Company'
+                ),
+            ],
+        ];
+    }
+
+    public function canView($member = null) 
+    {
+        return Permission::check('COMPANY_EDIT', 'any', $member);
+    }
+
+    public function canEdit($member = null) 
+    {
+        return Permission::check('COMPANY_EDIT', 'any', $member);
+    }
+
+    public function canDelete($member = null) 
+    {
+        return Permission::check('COMPANY_EDIT', 'any', $member);
+    }
+
+    public function canCreate($member = null, $context = []) 
+    {
+        return Permission::check('COMPANY_EDIT', 'any', $member);
+    }
+
 }

--- a/code/elemental/ElementalBehatTestAdmin.php
+++ b/code/elemental/ElementalBehatTestAdmin.php
@@ -14,4 +14,7 @@ class ElementalBehatTestAdmin extends ModelAdmin
     private static $managed_models = [
         ElementalBehatTestObject::class,
     ];
+
+    private static $required_permission_codes = 'CMS_ACCESS_CMSMain';
+
 }

--- a/code/elemental/ElementalBehatTestObject.php
+++ b/code/elemental/ElementalBehatTestObject.php
@@ -5,6 +5,7 @@ namespace SilverStripe\FrameworkTest\Elemental\Model;
 use SilverStripe\FrameworkTest\Elemental\Admin\ElementalBehatTestAdmin;
 use SilverStripe\Control\Controller;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\Security\Permission;
 
 class ElementalBehatTestObject extends DataObject
 {
@@ -23,4 +24,25 @@ class ElementalBehatTestObject extends DataObject
             $this->ID,
         );
     }
+
+    public function canView($member = null) 
+    {
+        return Permission::check(ElementalBehatTestAdmin::getRequiredPermissions() , 'any', $member);
+    }
+
+    public function canEdit($member = null) 
+    {
+        return Permission::check(ElementalBehatTestAdmin::getRequiredPermissions(), 'any', $member);
+    }
+
+    public function canDelete($member = null) 
+    {
+        return Permission::check(ElementalBehatTestAdmin::getRequiredPermissions(), 'any', $member);
+    }
+
+    public function canCreate($member = null, $context = []) 
+    {
+        return Permission::check(ElementalBehatTestAdmin::getRequiredPermissions(), 'any', $member);
+    }
+    
 }


### PR DESCRIPTION
### Description

Add `$required_permission_codes` for `'CMS_ACCESS_CMSMain'` in `ElementalBehatTestAdmin class` to support new changes in behat tests for Elemental module.

### Parent issue

- https://github.com/silverstripe/silverstripe-behat-extension/issues/220