### PR TITLE
ENH Stop using deprecated Versioned methods

### DIFF
--- a/code/TestPage.php
+++ b/code/TestPage.php
@@ -50,7 +50,7 @@ class TestPage extends Page implements \TestPageInterface
                 $parent = static::getOrCreateParentPage();
                 $page->ParentID = $parent->ID;
                 $page->write();
-                $page->publish('Stage', 'Live');
+                $page->copyVersionToStage('Stage', 'Live');
             });
         }
     }
@@ -72,7 +72,7 @@ class TestPage extends Page implements \TestPageInterface
                     )
                 );
                 $parent->write();
-                $parent->doPublish();
+                $parent->publishRecursive();
             }
         });
 

--- a/code/TestRegistryPage.php
+++ b/code/TestRegistryPage.php
@@ -21,7 +21,7 @@ class TestRegistryPage extends RegistryPage
                 $page->ParentID = $parent->ID;
                 $page->DataClass = TestRegistryDataObject::class;
                 $page->write();
-                $page->publish('Stage', 'Live');
+                $page->copyVersionToStage('Stage', 'Live');
             });
         }
     }

--- a/code/tasks/FTPageMakerTask.php
+++ b/code/tasks/FTPageMakerTask.php
@@ -82,7 +82,7 @@ class FTPageMakerTask extends BuildTask
             $page->ParentID = $parentID;
             $page->Title = "Test page {$fullPrefix}";
             $page->write();
-            $page->publish('Stage', 'Live');
+            $page->copyVersionToStage('Stage', 'Live');
 
             echo "Created '$page->Title' ($page->ClassName)\n";
 


### PR DESCRIPTION
The `publish()` and `doPublish()` methods are deprecated and should not be used.
The usage of these methods is causing problems with CMS 5 builds, so after merging this into `0.4`, merge-up immediately to `1`.

## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/10350