### PR TITLE
ENH Extracting logic for canX from Company and Employee

### DIFF
--- a/_config/extensions.yml
+++ b/_config/extensions.yml
@@ -7,6 +7,13 @@ SilverStripe\ORM\DataObject:
 SilverStripe\Assets\File:
   extensions:
     - BasicFieldsTestFileExtension
+
+SilverStripe\FrameworkTest\Model\Company:
+    extensions:
+    - SilverStripe\FrameworkTest\Extension\TestDataObjectExtension
+SilverStripe\FrameworkTest\Model\Employee:
+    extensions:
+    - SilverStripe\FrameworkTest\Extension\TestDataObjectExtension
     
 ---
 Only:

--- a/code/Company.php
+++ b/code/Company.php
@@ -13,8 +13,6 @@ use SilverStripe\Versioned\RecursivePublishable;
 use SilverStripe\Versioned\Versioned;
 use RelationFieldsTestPage;
 use GridFieldTestPage;
-use SilverStripe\Security\Permission;
-use SilverStripe\Security\PermissionProvider;
 
 /**
  *
@@ -33,7 +31,7 @@ use SilverStripe\Security\PermissionProvider;
  * @mixin Versioned
  * @mixin RecursivePublishable
  */
-class Company extends DataObject implements PermissionProvider
+class Company extends DataObject
 {
     private static $table_name = 'Company';
 
@@ -371,42 +369,6 @@ class Company extends DataObject implements PermissionProvider
     public function scaffoldSearchField()
     {
         return DropdownField::create('CompanyID', 'Company', self::get()->map())->setEmptyString('');
-    }
-
-    public function providePermissions()
-    {
-        return [
-            'COMPANY_EDIT' => [
-                'name' => _t(
-                    __CLASS__ . '.EditPermissionLabel',
-                    'Edit a company'
-                ),
-                'category' => _t(
-                    __CLASS__ . '.Category',
-                    'Company'
-                ),
-            ],
-        ];
-    }
-
-    public function canView($member = null) 
-    {
-        return Permission::check('COMPANY_EDIT', 'any', $member);
-    }
-
-    public function canEdit($member = null) 
-    {
-        return Permission::check('COMPANY_EDIT', 'any', $member);
-    }
-
-    public function canDelete($member = null) 
-    {
-        return Permission::check('COMPANY_EDIT', 'any', $member);
-    }
-
-    public function canCreate($member = null, $context = []) 
-    {
-        return Permission::check('COMPANY_EDIT', 'any', $member);
     }
 
 }

--- a/code/TestDataObjectExtension.php
+++ b/code/TestDataObjectExtension.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace SilverStripe\FrameworkTest\Extension;
+
+use SilverStripe\ORM\DataExtension;
+use SilverStripe\Security\Permission;
+use SilverStripe\Security\PermissionProvider;
+
+class TestDataObjectExtension extends DataExtension implements PermissionProvider
+{
+    public function providePermissions()
+    {
+        return [
+            'TEST_DATAOBJECT_EDIT' => [
+                'name' => _t(
+                    __CLASS__ . '.EditPermissionLabel',
+                    'Manage a test object'
+                ),
+                'category' => _t(
+                    __CLASS__ . '.Category',
+                    'Test Data Object'
+                ),
+            ],
+        ];
+    }
+
+    public function canView($member = null) 
+    {
+        return Permission::check('TEST_DATAOBJECT_EDIT', 'any', $member);
+    }
+
+    public function canEdit($member = null) 
+    {
+        return Permission::check('TEST_DATAOBJECT_EDIT', 'any', $member);
+    }
+
+    public function canDelete($member = null) 
+    {
+        return Permission::check('TEST_DATAOBJECT_EDIT', 'any', $member);
+    }
+
+    public function canCreate($member = null, $context = []) 
+    {
+        return Permission::check('TEST_DATAOBJECT_EDIT', 'any', $member);
+    }
+}


### PR DESCRIPTION
### Description 
- New DataObject Extension to provide canX permissions to extended `DataObject` in `frameworktest` module
- Append Extension to Company and Employee classes.

### Parent issue
- https://github.com/silverstripe/silverstripe-behat-extension/issues/220