### PR TITLE
MNT Don't require silverstripe/registry

### DIFF
--- a/code/TestRegistryDataObject.php
+++ b/code/TestRegistryDataObject.php
@@ -6,6 +6,10 @@ use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DB;
 use SilverStripe\Registry\RegistryDataInterface;
 
+if (!class_exists(RegistryDataInterface::class)) {
+    return;
+}
+
 class TestRegistryDataObject extends DataObject implements RegistryDataInterface
 {
     private static $table_name = 'TestRegistryDataObject';

--- a/code/TestRegistryPage.php
+++ b/code/TestRegistryPage.php
@@ -6,6 +6,10 @@ use SilverStripe\Registry\RegistryPage;
 use SilverStripe\Security\DefaultAdminService;
 use SilverStripe\Security\Member;
 
+if (!class_exists(RegistryPage::class)) {
+    return;
+}
+
 class TestRegistryPage extends RegistryPage
 {
     public function requireDefaultRecords()

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,7 @@
         "silverstripe/cms": "^5",
         "guzzlehttp/guzzle": "^7.4.5",
         "fzaninotto/faker": "^1.9.2",
-        "silverstripe/vendor-plugin": "^2",
-        "silverstripe/registry": "^3"
+        "silverstripe/vendor-plugin": "^2"
     },
     "extra": {
         "expose": [


### PR DESCRIPTION
Just because registry needs frameworktest doesn't mean frameworktest should need registry.
Having registry as a dependency means that any API breaking changes in core has potential to cause CI failures in registry - which means we have to mess around with this module when doing core stuff even though it's not core.

Created this PR because registry is causing CI issues: see https://github.com/silverstripe/silverstripe-admin/pull/1355

## Parent issue
- https://github.com/silverstripe/silverstripe-admin/issues/1354