### PR TITLE
FIX Use interface_exists

### DIFF
--- a/code/TestRegistryDataObject.php
+++ b/code/TestRegistryDataObject.php
@@ -6,7 +6,7 @@ use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DB;
 use SilverStripe\Registry\RegistryDataInterface;
 
-if (!class_exists(RegistryDataInterface::class)) {
+if (!interface_exists(RegistryDataInterface::class)) {
     return;
 }
 


### PR DESCRIPTION
Fixes issue on dev/build

```
ERROR [Emergency]: Uncaught SilverStripe\Core\Injector\InjectorNotFoundException: Class TestRegistryDataObject does not exist
IN GET dev/build
Line 13 in /var/www/vendor/silverstripe/framework/src/Core/Injector/InjectionCreator.php       
```