### PR TITLE
DEP Upgrade installer dependencies CMS5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "^8.1",
         "silverstripe/framework": "^5",
         "silverstripe/cms": "^5",
-        "guzzlehttp/guzzle": "^7.4.5",
+        "guzzlehttp/guzzle": "^7.5",
         "fzaninotto/faker": "^1.9.2",
         "silverstripe/vendor-plugin": "^2"
     },


### PR DESCRIPTION
### Parent issue
- https://github.com/silverstripe/silverstripe-installer/issues/335