### PR TITLE
NEW Add NullSpamProtector

### DIFF
--- a/_config/spamprotection.yml
+++ b/_config/spamprotection.yml
@@ -1,0 +1,5 @@
+---
+name: frameworktest-spamprotection
+---
+SilverStripe\SpamProtection\Extension\FormSpamProtectionExtension:
+  default_spam_protector: SilverStripe\FrameworkTest\NullSpamProtector\NullSpamProtector

--- a/code/null-spam-protector/NullSpamProtector.php
+++ b/code/null-spam-protector/NullSpamProtector.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace SilverStripe\FrameworkTest\NullSpamProtector;
+
+use SilverStripe\Forms\HiddenField;
+use SilverStripe\SpamProtection\SpamProtector;
+
+if (!interface_exists(SpamProtector::class)) {
+    return;
+}
+
+/**
+ * This is a minimum implementation used in CI for silverstripe/spamprotector so there's a default_spam_protector
+ *
+ * This used to be done by silverstripe/akismet, but that's no longer being used in CMS 5
+ */
+class NullSpamProtector implements SpamProtector
+{
+    public function getFormField($name = null, $title = null, $value = null)
+    {
+        return new HiddenField('NullSpamProtector');
+    }
+
+    public function setFieldMapping($fieldMapping)
+    {
+        // no-op
+    }
+}


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10402

This is required because we no longer support https://github.com/silverstripe/silverstripe-akismet/ which means there is no longer a default spam protector for recipes which had previously included it.

~~Create 1.1 branch and tag 1.1.0 after merging~~ Leave as 1.x-dev for now