### PR TITLE
MNT Add merge-up and keepalive workflows

### DIFF
--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,0 +1,17 @@
+name: Keepalive
+
+on:
+  # At 1:05 PM UTC, on day 22 of the month
+  schedule:
+    - cron: '5 13 22 * *'
+  workflow_dispatch:
+
+jobs:
+  keepalive:
+    name: Keepalive
+    # Only run cron on the silverstripe account
+    if: (github.event_name == 'schedule' && github.repository_owner == 'silverstripe') || (github.event_name != 'schedule')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Keepalive
+        uses: silverstripe/gha-keepalive@v1

--- a/.github/workflows/merge-up.yml
+++ b/.github/workflows/merge-up.yml
@@ -1,0 +1,17 @@
+name: Merge-up
+
+on:
+  # At 2:20 PM UTC, only on Saturday
+  schedule:
+    - cron: '20 14 * * 6'
+  workflow_dispatch:
+
+jobs:
+  merge-up:
+    name: Merge-up
+    # Only run cron on the silverstripe account
+    if: (github.event_name == 'schedule' && github.repository_owner == 'silverstripe') || (github.event_name != 'schedule')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Merge-up
+        uses: silverstripe/gha-merge-up@v1


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/99

One of the behat failures (validation.feature) was a result of something in frameworktest `0.4` not being merged-up to `1`

I've manually merged-up frameworktest for now to resolve

Add this so that it shouldn't happen again going forwards
