### PR TITLE
MNT Add dummy ci file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  ci:
+    # This is a dummy ci job added so that the gha-merge-up action will find a ci.yml file to run
+    name: CI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pass
+        run: |
+          echo "Passed"


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/209

Fixes https://github.com/silverstripe/silverstripe-frameworktest/actions/runs/8215187068/job/22468390243#step:2:1024

`Could not workflow file for branch 2 - tried action-ci-self.yml action-ci.yml ci.yml`

Re-run https://github.com/silverstripe/silverstripe-frameworktest/actions/runs/8215187068 after merge to confirm it works

