### PR TITLE
FIX Don't cause errors if elemental isn't installed

### DIFF
--- a/code/elemental/MultiElementalAreasExtension.php
+++ b/code/elemental/MultiElementalAreasExtension.php
@@ -5,6 +5,10 @@ namespace SilverStripe\FrameworkTest\Elemental\Extension;
 use DNADesign\Elemental\Extensions\ElementalAreasExtension;
 use DNADesign\Elemental\Models\ElementalArea;
 
+if (!class_exists(ElementalAreasExtension::class)) {
+    return;
+}
+
 /**
  * This is used to test multiple elemental areas on a page
  */


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-admin/actions/runs/10123308730 and others

> Uncaught Error: Class "DNADesign\Elemental\Extensions\ElementalAreasExtension" not found in /home/runner/work/silverstripe-admin/silverstripe-admin/vendor/silverstripe/frameworktest/code/elemental/MultiElementalAreasExtension.php:11

## Issue
- https://github.com/silverstripe/.github/issues/287