### PR TITLE
FIX Don't require classes that don't exist

### DIFF
--- a/code/elemental/MultiElementalBehatTestAdmin.php
+++ b/code/elemental/MultiElementalBehatTestAdmin.php
@@ -5,6 +5,10 @@ namespace SilverStripe\FrameworkTest\Elemental\Admin;
 use SilverStripe\Admin\ModelAdmin;
 use SilverStripe\FrameworkTest\Elemental\Model\MultiElementalBehatTestObject;
 
+if (!class_exists(MultiElementalBehatTestObject::class)) {
+    return;
+}
+
 class MutliElementalBehatTestAdmin extends ModelAdmin
 {
     private static $url_segment = 'multi-elemental-behat-test-admin';

--- a/code/elemental/MutliElementalBehatTestObject.php
+++ b/code/elemental/MutliElementalBehatTestObject.php
@@ -5,6 +5,10 @@ namespace SilverStripe\FrameworkTest\Elemental\Model;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\FrameworkTest\Elemental\Extension\MultiElementalAreasExtension;
 
+if (!class_exists(MultiElementalAreasExtension::class)) {
+    return;
+}
+
 class MultiElementalBehatTestObject extends DataObject
 {
     private static $db = [
@@ -17,22 +21,22 @@ class MultiElementalBehatTestObject extends DataObject
         MultiElementalAreasExtension::class,
     ];
 
-    public function canView($member = null) 
+    public function canView($member = null)
     {
         return true;
     }
 
-    public function canEdit($member = null) 
+    public function canEdit($member = null)
     {
         return true;
     }
 
-    public function canDelete($member = null) 
+    public function canDelete($member = null)
     {
         return true;
     }
 
-    public function canCreate($member = null, $context = []) 
+    public function canCreate($member = null, $context = [])
     {
         return true;
     }


### PR DESCRIPTION
Follow on from https://github.com/silverstripe/silverstripe-frameworktest/pull/194

If the extension doesn't exist, the model causes errors. If the model doesn't exist the admin probably will too.
See https://github.com/silverstripe/silverstripe-admin/actions/runs/10135520139/job/28023093972

## Issue
- https://github.com/silverstripe/.github/issues/287