### PR TITLE
FIX Only include extension if elemental is installed

### DIFF
--- a/_config/extensions.yml
+++ b/_config/extensions.yml
@@ -53,6 +53,10 @@ SilverStripe\FrameworkTest\Elemental\Model\ElementalBehatTestObject:
     - DNADesign\Elemental\Extensions\ElementalAreasExtension
     - SilverStripe\FrameworkTest\Elemental\Extension\ElementalBehatTestExtension
 
+SilverStripe\FrameworkTest\Elemental\Model\MultiElementalBehatTestObject:
+  extensions:
+    - SilverStripe\FrameworkTest\Elemental\Extension\MultiElementalAreasExtension
+
 BasicElementalPage:
   extensions:
     - DNADesign\Elemental\Extensions\ElementalPageExtension
@@ -68,7 +72,6 @@ SilverStripe\FrameworkTest\LinkField\PageTypes\LinkFieldTestPage:
 SilverStripe\FrameworkTest\Model\Company:
   extensions:
     - SilverStripe\FrameworkTest\LinkField\Extensions\CompanyExtension
-
 
 ---
 Only:

--- a/code/elemental/MultiElementalBehatTestAdmin.php
+++ b/code/elemental/MultiElementalBehatTestAdmin.php
@@ -5,10 +5,6 @@ namespace SilverStripe\FrameworkTest\Elemental\Admin;
 use SilverStripe\Admin\ModelAdmin;
 use SilverStripe\FrameworkTest\Elemental\Model\MultiElementalBehatTestObject;
 
-if (!class_exists(MultiElementalBehatTestObject::class)) {
-    return;
-}
-
 class MutliElementalBehatTestAdmin extends ModelAdmin
 {
     private static $url_segment = 'multi-elemental-behat-test-admin';

--- a/code/elemental/MutliElementalBehatTestObject.php
+++ b/code/elemental/MutliElementalBehatTestObject.php
@@ -3,11 +3,6 @@
 namespace SilverStripe\FrameworkTest\Elemental\Model;
 
 use SilverStripe\ORM\DataObject;
-use SilverStripe\FrameworkTest\Elemental\Extension\MultiElementalAreasExtension;
-
-if (!class_exists(MultiElementalAreasExtension::class)) {
-    return;
-}
 
 class MultiElementalBehatTestObject extends DataObject
 {
@@ -16,10 +11,6 @@ class MultiElementalBehatTestObject extends DataObject
     ];
 
     private static $table_name = 'ElementalMultiBehatTestObject';
-
-    private static $extensions = [
-        MultiElementalAreasExtension::class,
-    ];
 
     public function canView($member = null)
     {


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-versioned-admin/actions/runs/10103220915/job/28023353675 and various others

> Uncaught InvalidArgumentException: SilverStripe\FrameworkTest\Elemental\Model\MultiElementalBehatTestObject references nonexistent SilverStripe\FrameworkTest\Elemental\Extension\MultiElementalAreasExtension in 'extensions'

See https://github.com/silverstripe/silverstripe-framework/issues/9500 for context, but tl;dr is we can't use `class_exists` like this in this particular scenario.
Other classes here also use extensions this way - we've probably run into this problem before and just forgot.

## Issue
- https://github.com/silverstripe/.github/issues/287