### PR TITLE
FIX Update CMS fields now that they're being scaffolded

### DIFF
--- a/code/BasicFieldsTestPage.php
+++ b/code/BasicFieldsTestPage.php
@@ -41,8 +41,6 @@ class BasicFieldsTestPage extends TestPage
     private static $db = array(
         'CalendarDate' => 'Date',
         'Checkbox' => 'Boolean',
-        'ConfirmedPassword' => 'Varchar',
-        'CreditCard' => 'Varchar',
         'Date' => 'Date',
         'DateTime' => 'Datetime',
         'DateTimeWithCalendar' => 'Datetime',
@@ -64,8 +62,6 @@ class BasicFieldsTestPage extends TestPage
         'MyLabelledFieldGroupCheckbox' => 'Boolean',
         'Number' => 'Float',
         'OptionSet' => 'Varchar',
-        'Password' => 'Varchar',
-        'PhoneNumber' => 'Varchar',
         'Price' => 'Double',
         'Readonly' => 'Varchar',
         'Required' => 'Text',
@@ -79,9 +75,7 @@ class BasicFieldsTestPage extends TestPage
     );
 
     private static $has_one = array(
-        'AttachedFile' => 'SilverStripe\\Assets\\File',
         'Dropdown' => 'SilverStripe\\FrameworkTest\\Model\\TestCategory',
-        'File' => 'SilverStripe\\Assets\\File',
         'GroupedDropdown' => 'SilverStripe\\FrameworkTest\\Model\\TestCategory',
         'Image' => 'SilverStripe\\Assets\\Image',
     );
@@ -97,9 +91,30 @@ class BasicFieldsTestPage extends TestPage
     );
 
     private static $owns = [
-        'AttachedFile',
-        'File',
         'Image',
+    ];
+
+    private static array $scaffold_cms_fields_settings = [
+        'ignoreFields' => [
+            'MyCompositeField1',
+            'MyCompositeField2',
+            'MyCompositeField3',
+            'MyCompositeFieldCheckbox',
+            'MyFieldGroup1',
+            'MyFieldGroup2',
+            'MyFieldGroup3',
+            'MyFieldGroupCheckbox',
+            'MyLabelledFieldGroup1',
+            'MyLabelledFieldGroup2',
+            'MyLabelledFieldGroup3',
+            'MyLabelledFieldGroupCheckbox',
+            'ToggleCompositeTextField1',
+            'ToggleCompositeDropdownField',
+        ],
+        'ignoreRelations' => [
+            'CheckboxSet',
+            'Listbox',
+        ],
     ];
 
     private static $defaults = array(
@@ -140,8 +155,6 @@ class BasicFieldsTestPage extends TestPage
             'CalendarDate' => "2017-01-31",
             'Checkbox' => 1,
             // 'CheckboxSet' => null,
-            'ConfirmedPassword' => 'secret',
-            'CreditCard' => '4000400040004111',
             'Date' => "2017-01-31",
             'DateTime' => "2017-01-31 23:59",
             'DateTimeWithCalendar' => "2017-01-31 23:59",
@@ -166,8 +179,6 @@ class BasicFieldsTestPage extends TestPage
             'MyLabelledFieldGroupCheckbox' => true,
             'Number' => 99.123,
             'OptionSet' => $thirdCat->ID,
-            'Password' => 'My value (ä!)',
-            'PhoneNumber' => '021 1235',
             'Price' => 99.99,
             'Readonly' => 'My value (ä!)',
             'Required' => 'My required value (delete to test)',

--- a/code/FrameworkTestSiteTreeExtension.php
+++ b/code/FrameworkTestSiteTreeExtension.php
@@ -3,7 +3,15 @@
 use SilverStripe\ORM\DataExtension;
 class FrameworkTestSiteTreeExtension extends DataExtension
 {
-    
     private static $has_one = array('RelationFieldsTestPage' => 'RelationFieldsTestPage');
     private static $belongs_many_many = array('RelationFieldsTestPages' => 'RelationFieldsTestPage');
+
+    private static array $scaffold_cms_fields_settings = [
+        'ignoreFields' => [
+            'RelationFieldsTestPage',
+        ],
+        'ignoreRelations' => [
+            'RelationFieldsTestPages',
+        ],
+    ];
 }

--- a/code/GridFieldTestPage.php
+++ b/code/GridFieldTestPage.php
@@ -30,6 +30,16 @@ class GridFieldTestPage extends TestPage
         'HasManyCompanies',
     ];
 
+    private static array $scaffold_cms_fields_settings = [
+        'ignoreFields' => [
+            'HasOneCompany',
+        ],
+        'ignoreRelations' => [
+            'HasManyCompanies',
+            'ManyManyCompanies',
+        ],
+    ];
+
     public function getCMSFields()
     {
         $fields = parent::getCMSFields();

--- a/code/RelationFieldsTestPage.php
+++ b/code/RelationFieldsTestPage.php
@@ -30,6 +30,16 @@ class RelationFieldsTestPage extends TestPage
         'Title' => 'Relational Fields'
     );
 
+    private static array $scaffold_cms_fields_settings = [
+        'ignoreFields' => [
+            'HasOneCompany',
+        ],
+        'ignoreRelations' => [
+            'HasManyCompanies',
+            'ManyManyCompanies',
+        ],
+    ];
+
     public function getCMSFields()
     {
         $fields = parent::getCMSFields();

--- a/code/multitab-validation/MultiTabPage.php
+++ b/code/multitab-validation/MultiTabPage.php
@@ -26,6 +26,12 @@ class MultiTabPage extends Page
         'SettingsTabFirstField' => 'Varchar(50)',
     ];
 
+    private static array $scaffold_cms_fields_settings = [
+        'ignoreFields' => [
+            'SettingsTabFirstField',
+        ],
+    ];
+
     public function getCMSFields()
     {
         $fields = parent::getCMSFields();


### PR DESCRIPTION
Relies on changes to `SiteTree` in https://github.com/silverstripe/silverstripe-cms/pull/2983


## Issue
- https://github.com/silverstripe/silverstripe-cms/issues/2767