### PR TITLE
ENH Add a status flag for companies that we can behat test against

### DIFF
--- a/code/Company.php
+++ b/code/Company.php
@@ -368,4 +368,15 @@ class Company extends DataObject
         return DropdownField::create('CompanyID', 'Company', Company::get()->map())->setEmptyString('');
     }
 
+    public function getStatusFlags(bool $cached = true): array
+    {
+        $this->beforeExtending('updateStatusFlags', function (array &$flags) {
+            $flags['company-status-flag1'] = 'string-flag';
+            $flags['company-status-flag2'] = [
+                'title' => 'a flag with a title',
+                'text' => 'array-flag',
+            ];
+        });
+        return parent::getStatusFlags($cached);
+    }
 }


### PR DESCRIPTION
Displayed in each row of the gridfield for this model:
![Screenshot from 2024-11-20 14-56-03](https://github.com/user-attachments/assets/9ad228bd-5128-409b-a1e1-b9c80fbeee5d)

Displayed in the breadcrumbs of the gridfield edit form for this model:
![Screenshot from 2024-11-20 14-55-48](https://github.com/user-attachments/assets/668f925c-344b-4a75-8ceb-1802772e7769)

Hovering over "array-flag" gives you some additional text, but hovering over "string-tag" does not.

## Issue
- https://github.com/silverstripe/silverstripe-cms/issues/2947