### PR TITLE
DEP Don't include vendor-plugin as an explicit dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
         "silverstripe/framework": "^6",
         "silverstripe/cms": "^6",
         "guzzlehttp/guzzle": "^7.9",
-        "fzaninotto/faker": "^1.9.2",
-        "silverstripe/vendor-plugin": "^2"
+        "fzaninotto/faker": "^1.9.2"
     },
     "extra": {
         "expose": [


### PR DESCRIPTION
We don't directly reference it in code or config, so we can rely on silverstripe/framework having this dependency for us.


## Issue
- https://github.com/silverstripe/.github/issues/311