### PR TITLE
ENH Use new DataList caching

### DIFF
--- a/code/BasicFieldsTestPage.php
+++ b/code/BasicFieldsTestPage.php
@@ -127,7 +127,8 @@ class BasicFieldsTestPage extends TestPage
     {
         parent::requireDefaultRecords();
 
-        if ($inst = DataObject::get_one('BasicFieldsTestPage') && static::config()->get('regenerate_on_build')) {
+        $inst = BasicFieldsTestPage::get()->setUseCache(true)->first();
+        if ($inst && static::config()->get('regenerate_on_build')) {
             $data = $this->getDefaultData();
             $inst->update($data);
             $inst->write();
@@ -139,7 +140,6 @@ class BasicFieldsTestPage extends TestPage
             $inst->Listbox()->add($thirdCat);
             $inst->CheckboxSet()->add($firstCat);
             $inst->CheckboxSet()->add($thirdCat);
-
         }
     }
 

--- a/code/TestCategory.php
+++ b/code/TestCategory.php
@@ -36,7 +36,7 @@ class TestCategory extends DataObject
 
     public function requireDefaultRecords()
     {
-        if (!DataObject::get_one(static::class)) {
+        if (static::get()->count() === 0) {
             foreach (array("A", "B", "C", "D") as $item) {
                 $page = new static();
                 $page->Title = "Test Category $item";

--- a/code/TestPage.php
+++ b/code/TestPage.php
@@ -40,7 +40,7 @@ class TestPage extends Page implements \TestPageInterface
             return;
         }
 
-        if (!DataObject::get_one(static::class)) {
+        if (static::get()->count() === 0) {
             // Try to create common parent
             $defaultAdminService = DefaultAdminService::singleton();
             Member::actAs($defaultAdminService->findOrCreateDefaultAdmin(), function () {

--- a/code/TestRegistryPage.php
+++ b/code/TestRegistryPage.php
@@ -11,7 +11,7 @@ if (class_exists(RegistryPage::class)) {
     {
         public function requireDefaultRecords()
         {
-            if (!DataObject::get_one(static::class)) {
+            if (static::get()->count() === 0) {
                 // Try to create common parent
                 $defaultAdminService = DefaultAdminService::singleton();
                 Member::actAs($defaultAdminService->findOrCreateDefaultAdmin(), function () {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": "^8.3",
-        "silverstripe/framework": "^6",
+        "silverstripe/framework": "^6.1",
         "silverstripe/cms": "^6",
         "guzzlehttp/guzzle": "^7.9",
         "fzaninotto/faker": "^1.9.2"


### PR DESCRIPTION
Replaces deprecated `DataObject::get_one()` and `DataObject::get_by_id()` in favour of the new DataList query caching.

> [!IMPORTANT]
> Relies on https://github.com/silverstripe/silverstripe-framework/pull/11768
> DO NOT MERGE until that PR has been merged in

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11767
