### PR TITLE
FIX Don't use new feature in frameworktest

### DIFF
--- a/code/BasicFieldsTestPage.php
+++ b/code/BasicFieldsTestPage.php
@@ -127,7 +127,7 @@ class BasicFieldsTestPage extends TestPage
     {
         parent::requireDefaultRecords();
 
-        $inst = BasicFieldsTestPage::get()->setUseCache(true)->first();
+        $inst = BasicFieldsTestPage::get()->first();
         if ($inst && static::config()->get('regenerate_on_build')) {
             $data = $this->getDefaultData();
             $inst->update($data);

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": "^8.3",
-        "silverstripe/framework": "^6.1",
+        "silverstripe/framework": "^6",
         "silverstripe/cms": "^6",
         "guzzlehttp/guzzle": "^7.9",
         "fzaninotto/faker": "^1.9.2"


### PR DESCRIPTION
We don't actually need this caching here so it's easiest to just remove it and revert the constraint change.

## Issue

- https://github.com/silverstripe/silverstripe-frameworktest/issues/239