### PR TITLE
ENH Include GridField_ActionMenu in config

### DIFF
--- a/code/GridFieldArbitraryData/ArbitraryDataAdmin.php
+++ b/code/GridFieldArbitraryData/ArbitraryDataAdmin.php
@@ -18,6 +18,7 @@ use SilverStripe\Forms\GridField\GridFieldFilterHeader;
 use SilverStripe\Forms\GridField\GridFieldPaginator;
 use SilverStripe\Forms\GridField\GridFieldPrintButton;
 use SilverStripe\Forms\GridField\GridFieldViewButton;
+use SilverStripe\Forms\GridField\GridField_ActionMenu;
 use SilverStripe\Forms\HiddenField;
 use SilverStripe\Forms\TextField;
 use SilverStripe\Model\List\ArrayList;
@@ -110,6 +111,7 @@ class ArbitraryDataAdmin extends LeftAndMain
         } else {
             // This is effectively the same as a GridFieldConfig_RecordViewer, but without removing the GridFieldFilterHeader.
             $config = GridFieldConfig_Base::create();
+            $config->addComponent(GridField_ActionMenu::create());
             $config->addComponent(GridFieldViewButton::create());
             $config->addComponent(GridFieldDetailForm::create());
             $fieldNames = array_keys(ArbitraryDataAdmin::getInitialRecords()[0]);


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11842

There is only one template being rendered. What's happening is that the GridFieldViewButton is being rendered, then there's some react that will transform the action menu (if present) based on the contents of the `data-schema` attribute on the action menu element

Have a look at the following to see the flow:

- [GridFieldViewButton::getExtraData()](https://github.com/silverstripe/silverstripe-framework/blob/6/src/Forms/GridField/GridFieldViewButton.php#L48)
- [GridField_ActionMenu::getColumnContent()](https://github.com/silverstripe/silverstripe-framework/blob/6/src/Forms/GridField/GridField_ActionMenu.php#L45)
- [GridField_ActionMenu.ss](https://github.com/silverstripe/silverstripe-framework/blob/6/src/Forms/GridField/GridField_ActionMenu.php#L45)
- [GridField.refresh()](https://github.com/silverstripe/silverstripe-admin/blob/3/client/src/legacy/GridField.js#L320)
- [GridFieldActions.renderSingleAction()](https://github.com/silverstripe/silverstripe-admin/blob/3/client/src/components/GridFieldActions/GridFieldActions.js#L75)

This PR will add the GridField_ActionMenu component will make the view action in arbitrary data look like the 'normal' view action